### PR TITLE
Fix binomial tree edge rendering

### DIFF
--- a/src/BinaryTree/components/TreeSVG.tsx
+++ b/src/BinaryTree/components/TreeSVG.tsx
@@ -110,6 +110,8 @@ export function TreeSVG({ kind, root, binomialHead, viewBox }: TreeSVGProps) {
       edges.push(...renderBinomialEdges(child));
       child = child.sibling;
     }
+    // Also render edges for any sibling trees so the entire forest is shown
+    edges.push(...renderBinomialEdges(node.sibling));
     return edges;
   };
 


### PR DESCRIPTION
## Summary
- render edges for all binomial trees in the forest

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683f3fa123408321a787b32d10960a6e